### PR TITLE
44 change packing queue base on router

### DIFF
--- a/src/packingSlip/controller.js
+++ b/src/packingSlip/controller.js
@@ -396,7 +396,7 @@ async function getAllPackingSlips(_req, res) {
 async function createPackingSlip(req, res) {
   ExpressHandler(
     async () => {
-      const { items, orderNumber, customer, destination } = req.body;
+      const { items, orderNumber, customer, destination, destinationCode } = req.body;
 
       if (destination !== "VENDOR" && destination !== "CUSTOMER") {
         return HTTPError("Destination must be either vendor or customer.", 400);
@@ -414,6 +414,7 @@ async function createPackingSlip(req, res) {
         items,
         createdBy: req.user._id,
         destination,
+        destinationCode,
       });
 
       await packingSlip.save();

--- a/src/packingSlip/model.js
+++ b/src/packingSlip/model.js
@@ -61,6 +61,8 @@ const schema = new Schema({
     type: String,
     default: 'CUSTOMER'
   },
+
+  destinationCode: String,
 });
 
 const Model = model("packingSlip", schema, "packingSlips");

--- a/src/workOrder/controller.js
+++ b/src/workOrder/controller.js
@@ -124,8 +124,17 @@ async function getAllWithPackedQties(showFulfilled) {
               partNumber: { $first: "$Items.PartNumber" },
               orderNumber: { $first: "$Items.OrderNumber" },
               partDescription: { $first: "$Items.PartName" },
-              shippingInfo: { $first: '$Items.partRouter' }
+              shippingInfo: { $first: '$Items.partRouter' },
+              released: { $first: '$Items.released' },
             },
+          },
+          //only get released parts
+          { 
+            $match: {
+              $expr: {
+                $eq: [ '$released', true ]
+              }
+            }
           },
           { 
             $unwind: {
@@ -220,6 +229,7 @@ async function getAllWithPackedQties(showFulfilled) {
   try {
     const d = await ShopQueue.aggregate(agg);
     const data = d?.[0]?.activeWorkOrders;
+    console.log(data)
 
     const customerTags = new Set();
     data.forEach((x) => {


### PR DESCRIPTION
Closes #44 

Solution:
* In `getAllWithPackedQties`: 
  * Updated pipeline to filter by only `released` jobs
  * Added logic to populate fields `destination` and `destinationCode` based on `step.name`, `stepCode`, and if `partRouter` exists for each job
* Added `destinationCode` as type `String` to `packingSlips` model
* Updated `createPackingSlip` to send `destinationCode`

Notes:
* The logic for setting the `destinationCode` field in the pipeline is a little messy. I tried to leave comments to make navigation a little easier. It could be written as an additional `$addFields` stage but that would cost another iteration. 