### PR TITLE
Get incoming Delivery Queue

### DIFF
--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -2,6 +2,7 @@ const { Router } = require('express');
 const router = Router();
 const { LogError, ExpressHandler, HTTPError } = require('../utils');
 const IncomingDelivery = require('./model');    //causing an error
+const WorkOrder = require('../workOrder/model');
 
 router.get('/', getAll);
 router.put('/', createOne);
@@ -94,7 +95,86 @@ function createOne(req, res) {
  * Get the queue of incoming deliveries that have not yet been received.
  */
 function getQueue(req, res) {
+  ExpressHandler( 
+    async () => { 
+      const query = { receivedOn: { $exists: false } };
+      const _deliveries = await IncomingDelivery.find(query)
+        .lean()
+        .populate({
+          path: 'sourceShipmentId',
+          populate: {
+            path: 'manifest',
+            model: 'packingSlip',
+          }
+        })
+        .exec();
 
+      const ordersSet = new Set();    //use to track all workOrders that need to be fetched
+      const itesmObjs = {};
+      const promises = [];
+
+      //map _deliveries into almost final format
+      const deliveries = _deliveries.map( (x) => {
+        const { _id, label, sourceShipmentId } = x;
+        
+        const manifestArr = [];
+        for ( m of sourceShipmentId.manifest ) {
+          manifestArr.push(...m.items)
+
+           //check if ordersSet has order number already, add if not
+          if ( ordersSet.has(m.orderNumber) === false ) {
+            ordersSet.add(m.orderNumber)
+            promises.push( _populateItems(m.orderNumber) )
+          }
+        }
+
+        const _obj = {
+          _id,
+          label,
+          manifest: manifestArr, 
+          source: m.destination,
+        };
+
+        return _obj;
+      })
+
+      await Promise.all(promises)
+
+      //helper to get item info from workOrder
+      async function _populateItems(orderNumber) {
+        const workOrder = await WorkOrder.findOne({ OrderNumber: orderNumber })
+          .lean()
+          .select('Items')
+          .exec();
+
+        for ( const woItem of workOrder.Items ) {
+          const { OrderNumber, PartNumber, PartName, Revision, batchNumber } = woItem;
+          const _woItem = {
+            orderNumber: OrderNumber,
+            partNumber: PartNumber,
+            partDescription: PartName,
+            partRev: Revision,
+            batch: batchNumber,
+          };
+          itesmObjs[woItem._id] = _woItem;
+        }
+      };
+
+      //loop through deliveries and set item value
+      for ( const delivery of deliveries ) {
+        for ( m of delivery.manifest ) {
+          delete m._id;
+          const itemId = m.item;
+          m.item = itesmObjs[itemId];
+        }
+      }     
+
+      const data = { deliveries };
+      return { data };
+    }, 
+    res, 
+    'fetching incoming deliveries queue' 
+  );
 }
 
 /**


### PR DESCRIPTION
Closes PS-7

Solution: 
* Query all `incomingDeliveries` that do not have a `receivedOn` date.
* Manipulate data to almost the desired format while fetching `WorkOrder` information for each item (as needed).
* Loop through main data set again to populate the `delivery.manifest[idx].item` information to align with required format.