### PR TITLE
Create new incoming delivery on new ps 22

### DIFF
--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -81,7 +81,7 @@ function createOne(req, res) {
       } = req.body;
 
       const [err, data] = await CreateNew(internalPurchaseOrderNumber, req.user._id, isDueBackOn, sourceShipmentId);
-      if ( err ) HTTPError('Error creating new incoming delivery.');
+      if ( err ) return err;
 
       return { data };
     }, 

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -112,8 +112,6 @@ function getQueue(req, res) {
           }
         })
         .exec();
-
-      console.debug(_deliveries);
       
       const ordersSet = new Set();    //use to track all workOrders that need to be fetched
       const itemsObjs = {};

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -28,31 +28,35 @@ async function CreateNew(
   internalPurchaseOrderNumber,
   creatingUserId,
   isDueBackOn,
-  label,
   sourceShipmentId=undefined
 ) {
+  if ( !sourceShipmentId ) return [ HTTPError('Shipment ID not sent.', 400) ];
+
+  const [err, ret] = await getSourceShipmentLabel(sourceShipmentId);
+  if ( err ) return [ err ];
+
+  const { numberOfDeliveries, shipmentId } = ret;
+  let label = shipmentId + '-R';
+  if ( numberOfDeliveries > 0 ) label += `${numberOfDeliveries + 1}`;
+
+  const deliveryInfo = {
+    internalPurchaseOrderNumber,
+    createdBy: creatingUserId,
+    isDueBackOn,
+    sourceShipmentId,
+    label,
+  };
+
   try {
-    const deliveryInfo = {
-      internalPurchaseOrderNumber,
-      createdBy: creatingUserId,
-      isDueBackOn,
-      sourceShipmentId,
-      label,
-    };
+    const incomingDelivery = new IncomingDelivery(deliveryInfo);
+    await incomingDelivery.save();
 
-    if ( !sourceShipmentId ) return [ { message: 'no shipment id sent', code: 501 }, ];
-
-    const newIncomingDelivery = new IncomingDelivery(deliveryInfo);
-    await newIncomingDelivery.save();
-
-    return [ , newIncomingDelivery._id];
+    return [ , { incomingDelivery }];
   } 
   catch (error) {
     LogError(error);
-    return [error];
+    return [ HTTPError('Unexpected error creating incoming delivery.') ];
   }
-  
-  // throw new Error('Not implemented.');
 }
 
 /**
@@ -75,26 +79,9 @@ function createOne(req, res) {
         sourceShipmentId
       } = req.body;
 
-      const { _id } = req.user;
+      const [err, data] = await CreateNew(internalPurchaseOrderNumber, req.user._id, isDueBackOn, sourceShipmentId);
+      if ( err ) HTTPError('Error creating new incoming delivery.');
 
-      const [err, ret] = await _getSourceShipmentLabel(sourceShipmentId);
-      if ( err ) return HTTPError('error getting source shipment info');
-
-      const { numberOfDeliveries, shipmentId } = ret;
-      let label = shipmentId + '-R';
-      if ( numberOfDeliveries > 0 ) label += `${numberOfDeliveries + 1}`;
-
-      const [err2, incomingDeliveryId] = await CreateNew(
-        internalPurchaseOrderNumber,
-        _id,
-        isDueBackOn,
-        label,
-        sourceShipmentId,
-      );
-
-      if ( err2 ) HTTPError('error creating new incoming delivery');
-
-      const data = { incomingDeliveryId };
       return { data };
     }, 
     res, 
@@ -225,7 +212,7 @@ function setReceived(req, res) {
   );
 }
 
-async function _getSourceShipmentLabel(id) {
+async function getSourceShipmentLabel(id) {
   try {
     const shipment = await Shipment.findOne({ _id: id })
       .lean()
@@ -251,6 +238,6 @@ async function _getSourceShipmentLabel(id) {
   } 
   catch (error) {
     LogError(error);
-    return [error];
+    return [ HTTPError('Unexpected error fetching shipment info for labeling.') ];
   }
 }


### PR DESCRIPTION
Realized while checking other MRs that `PUT /shipments` was missing logic to create incoming delivery when `isDueBack*` is passed.

Simply logic but required moving some stuff around for re-usability.

I kinda blasted through this one so I could use some checks on my error handlers
Functionality is all there 

ps. i did not add logic to test is `isDueBackOn` is a valid date or not, but that should be done.