### PR TITLE
Display all jobs in the planning queue mq 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.env
 !.dev.env
 **/*.log
+**/.vscode

--- a/package.json
+++ b/package.json
@@ -51,5 +51,12 @@
     "test": "ts-mocha -p ./tsconfig.json --bail --recursive --exit --timeout 5000 tests/**/*.spec.ts",
     "lint": "eslint ."
   },
-  "eslintIgnore": ["tests"]
+  "eslintIgnore": [
+    "tests"
+  ],
+  "prettier": {
+    "jsxSingleQuote": true,
+    "singleQuote": true,
+    "trailingComma": "all"
+  }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import passport from 'passport';
 import mongoose from 'mongoose';
 import debugRouter from './router.debug';
 import { LotRouter } from './lot/controller';
+import JobRouter from './job/controller';
 import RouteStepRouter from './routeStep/controller';
 
 require('dotenv').config();
@@ -16,19 +17,21 @@ require('./config.passport')(passport);
 const app = express();
 export { app };
 
-app.use(cors({
-  origin: [
-    process.env.CORS_CLIENT_URL!,
-  ],
-  credentials: true,
-}));
+app.use(
+  cors({
+    origin: [process.env.CORS_CLIENT_URL!],
+    credentials: true,
+  }),
+);
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(cookieSession({
-  name: process.env.SESSION_NAME,
-  keys: [process.env.SESSION_SECRET!],
-}));
+app.use(
+  cookieSession({
+    name: process.env.SESSION_NAME,
+    keys: [process.env.SESSION_SECRET!],
+  }),
+);
 
 app.use(passport.initialize());
 app.use(passport.session());
@@ -49,10 +52,9 @@ app.use('/packingSlips', require('./packingSlip/controller').router);
 app.use('/workOrders', require('./workOrder/controller'));
 app.use('/shipments', require('./shipment/controller'));
 app.use('/users', require('./user/controller'));
-
 app.use('/routeSteps', RouteStepRouter);
-
 app.use('/lots', LotRouter);
+app.use('/jobs', JobRouter);
 
 app.all('*', (_req, res) => res.sendStatus(404));
 

--- a/src/job/controller.ts
+++ b/src/job/controller.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { JobModel } from './model';
+import { ExpressHandler } from '../utils';
+
+const JobRouter = express.Router();
+JobRouter.get('/', getJobs);
+
+async function getJobs(_req: express.Request, res: express.Response) {
+  ExpressHandler(
+    async () => {
+      const jobs = await JobModel.find().lean();
+
+      const data = { jobs };
+      return { data };
+    },
+    res,
+    'getting all jobs',
+  );
+}
+
+export default JobRouter;

--- a/tests/unit/job.spec.ts
+++ b/tests/unit/job.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { MongoClient } from "mongodb";
+import { ChaiRequest } from "../config";
+
+require("../config"); // recommended way of loading root hooks
+
+const URL = "/jobs";
+
+// set up DB_URL - NOTE: this only works with a local db, if not set up use the /debug/reset route to generate data (this might not be needed)
+const DB_URL: string = process.env.MONGO_DB_URI!;
+// FYI for this there is a permission issue of trying to go to a new db, currently I don't have a local db set up
+
+const CLIENT = new MongoClient(DB_URL);
+
+describe("# JOB", () => {
+  it("Should find 1 inserted job.", async () => {
+    // set up connection to db
+    await CLIENT.connect().catch(console.error);
+
+    // create job using mongodb driver
+    const doc = {
+      partId: "partId",
+      dueDate: "2022/10/14",
+      batchQty: 1,
+      material: "moondust",
+      externalPostProcesses: ["pp2", "pp1"],
+      lots: ["lotId1", "lotid2"],
+      released: false,
+      onHold: true,
+      canceled: true,
+      stdLotSize: 1,
+    };
+    await CLIENT.db().collection("jobs").insertOne(doc);
+
+    // hit endpoint to get all jobs in collection
+    const res = await ChaiRequest("get", `${URL}/`);
+    expect(res.body.jobs.length).to.be.eq(1);
+
+    // check data
+    const job = res.body.jobs[0];
+    expect(job.partId).to.be.eq("partId");
+    expect(job.dueDate).to.be.eq("2022/10/14");
+    expect(job.batchQty).to.be.eq(1);
+    expect(job.material).to.be.eq("moondust");
+    expect(job.externalPostProcesses).to.have.members(["pp2", "pp1"]);
+    expect(job.lots).to.have.members(["lotId1", "lotid2"]);
+    expect(job.released).to.be.eq(false);
+    expect(job.onHold).to.be.eq(true);
+    expect(job.stdLotSize).to.be.eq(1);
+  });
+});

--- a/tests/unit/job.spec.ts
+++ b/tests/unit/job.spec.ts
@@ -1,11 +1,12 @@
-import { expect } from "chai";
-import { describe, it } from "mocha";
-import { MongoClient } from "mongodb";
-import { ChaiRequest } from "../config";
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { MongoClient } from 'mongodb';
+import { DropAllCollections } from '../../src/router.debug';
+import { ChaiRequest } from '../config';
 
-require("../config"); // recommended way of loading root hooks
+require('../config'); // recommended way of loading root hooks
 
-const URL = "/jobs";
+const URL = '/jobs';
 
 // set up DB_URL - NOTE: this only works with a local db, if not set up use the /debug/reset route to generate data (this might not be needed)
 const DB_URL: string = process.env.MONGO_DB_URI!;
@@ -13,38 +14,41 @@ const DB_URL: string = process.env.MONGO_DB_URI!;
 
 const CLIENT = new MongoClient(DB_URL);
 
-describe("# JOB", () => {
-  it("Should find 1 inserted job.", async () => {
-    // set up connection to db
+describe('# JOB', () => {
+  before(async function () {
     await CLIENT.connect().catch(console.error);
-
+  });
+  afterEach(async function () {
+    await DropAllCollections();
+  });
+  it('Should find 1 inserted job.', async () => {
     // create job using mongodb driver
     const doc = {
-      partId: "partId",
-      dueDate: "2022/10/14",
+      partId: 'partId',
+      dueDate: '2022/10/14',
       batchQty: 1,
-      material: "moondust",
-      externalPostProcesses: ["pp2", "pp1"],
-      lots: ["lotId1", "lotid2"],
+      material: 'moondust',
+      externalPostProcesses: ['pp2', 'pp1'],
+      lots: ['lotId1', 'lotid2'],
       released: false,
       onHold: true,
       canceled: true,
       stdLotSize: 1,
     };
-    await CLIENT.db().collection("jobs").insertOne(doc);
+    await CLIENT.db().collection('jobs').insertOne(doc);
 
     // hit endpoint to get all jobs in collection
-    const res = await ChaiRequest("get", `${URL}/`);
+    const res = await ChaiRequest('get', `${URL}/`);
     expect(res.body.jobs.length).to.be.eq(1);
 
     // check data
     const job = res.body.jobs[0];
-    expect(job.partId).to.be.eq("partId");
-    expect(job.dueDate).to.be.eq("2022/10/14");
+    expect(job.partId).to.be.eq('partId');
+    expect(job.dueDate).to.be.eq('2022/10/14');
     expect(job.batchQty).to.be.eq(1);
-    expect(job.material).to.be.eq("moondust");
-    expect(job.externalPostProcesses).to.have.members(["pp2", "pp1"]);
-    expect(job.lots).to.have.members(["lotId1", "lotid2"]);
+    expect(job.material).to.be.eq('moondust');
+    expect(job.externalPostProcesses).to.have.members(['pp2', 'pp1']);
+    expect(job.lots).to.have.members(['lotId1', 'lotid2']);
     expect(job.released).to.be.eq(false);
     expect(job.onHold).to.be.eq(true);
     expect(job.stdLotSize).to.be.eq(1);


### PR DESCRIPTION
Added GET /jobs and corresponding test.

@jarrilla This simply retrieves all jobs. If there should be a condition based on some Job properties, let me know.

Added a few prettier rules to package.json that are in line with the linter. This allows autosaving so that prettier and linter work together. I thought it would be a good idea to have it as part of the project to have a single source of truth.