### PR TITLE
Add missing `item._id` inside return `manifest`.

### DIFF
--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -324,9 +324,10 @@ function getOne(req, res) {
   ExpressHandler(
     async () => {
       const { deliveryId } = req.params;
-      const incomingDelivery = await IncomingDelivery.findOne({
-        _id: deliveryId,
-      })
+      const incomingDelivery = await IncomingDelivery
+        .findOne({
+          _id: deliveryId,
+        })
         .populate({
           path: "sourceShipmentId",
           populate: {
@@ -368,7 +369,7 @@ function getOne(req, res) {
 
         // only send some data
         const { PartNumber, PartName, Revision, Quantity, batchNumber } = _item;
-        mItem.item = { PartNumber, PartName, Revision, Quantity, batchNumber };
+        mItem.item = { PartNumber, PartName, Revision, Quantity, batchNumber, _id: _item._id };
       }
 
       const data = { incomingDelivery };

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -324,29 +324,20 @@ function getOne(req, res) {
   ExpressHandler(
     async () => {
       const { deliveryId } = req.params;
+      if (!deliveryId) return HTTPError("DeliveryId is required.", 400);
+
       const incomingDelivery = await IncomingDelivery
         .findOne({
           _id: deliveryId,
         })
-        .populate({
-          path: "sourceShipmentId",
-          populate: {
-            path: "manifest",
-            model: "packingSlip",
-          },
-        })
         .lean()
         .exec();
 
-      if (!incomingDelivery) return HTTPError("delivery not found");
+      if (!incomingDelivery) return HTTPError("Incoming delivery not found.", 404);
 
       const { orderNumber } = incomingDelivery.sourceShipmentId.manifest[0];
 
       // mutate data as needed
-      const newManifest = incomingDelivery.sourceShipmentId.manifest
-        .map((ps) => ps.items)
-        .flat();
-      incomingDelivery.sourceShipmentId.manifest = newManifest;
       if (!incomingDelivery.createdBy) incomingDelivery.createdBy = "AUTO";
       incomingDelivery.source = "VENDOR";
 
@@ -356,20 +347,20 @@ function getOne(req, res) {
         .select("Items")
         .exec();
 
-      if (!workOrder) return HTTPError("workOrder not found");
+      if (!workOrder) return HTTPError("Work Order not found.", 404);
       if (workOrder.Items.length === 0)
-        return HTTPError("no workOrder items found on workOrder");
+        return HTTPError("No Work Order Items found on Work Order.", 404);
 
-      // update manifest[].item to item info (can reduce what info is set to reduce the amount of data being sent)
-      for (const mItem of incomingDelivery.sourceShipmentId.manifest) {
-        const itemId = mItem.item.toString();
-        const _item = workOrder.Items.find((x) => x._id.toString() === itemId);
-        if (!_item)
-          return HTTPError(`item not found on workOrder ${orderNumber}`);
+      // set incomingDelivery.receivedQuantities[].item to item info
+      // (can reduce what info is set to reduce the amount of data being sent)
+      for (const el of incomingDelivery.receivedQuantities) {
+        const itemId = String(el.item);
+        const itemMatch = workOrder.Items.find( x => String(x._id) === itemId );
 
-        // only send some data
-        const { PartNumber, PartName, Revision, Quantity, batchNumber } = _item;
-        mItem.item = { PartNumber, PartName, Revision, Quantity, batchNumber, _id: _item._id };
+        if (!_item) return HTTPError(`Item not found on workOrder ${orderNumber}.`);
+
+        const { PartNumber, PartName, Revision, Quantity, batchNumber } = itemMatch;
+        el.item = { PartNumber, PartName, Revision, Quantity, batchNumber, _id: itemId };
       }
 
       const data = { incomingDelivery };

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -326,9 +326,15 @@ function getOne(req, res) {
       const { deliveryId } = req.params;
       if (!deliveryId) return HTTPError("DeliveryId is required.", 400);
 
-      const incomingDelivery = await IncomingDelivery
-        .findOne({
-          _id: deliveryId,
+      const incomingDelivery = await IncomingDelivery.findOne({
+        _id: deliveryId,
+      })
+        .populate({
+          path: "sourceShipmentId",
+          populate: {
+            path: "manifest",
+            model: "packingSlip",
+          },
         })
         .lean()
         .exec();
@@ -357,7 +363,7 @@ function getOne(req, res) {
         const itemId = String(el.item);
         const itemMatch = workOrder.Items.find( x => String(x._id) === itemId );
 
-        if (!_item) return HTTPError(`Item not found on workOrder ${orderNumber}.`);
+        if (!itemMatch) return HTTPError(`Item not found on workOrder ${orderNumber}.`);
 
         const { PartNumber, PartName, Revision, Quantity, batchNumber } = itemMatch;
         el.item = { PartNumber, PartName, Revision, Quantity, batchNumber, _id: itemId };


### PR DESCRIPTION
Where previously we were returning something like

```
"sourceShipmentId": {
  "_id": "635c8127a790e959f47f85ec",
    "manifest": [
      {
        "_id": "635c811ba790e959f47f85e1",
        "item": { 
          "PartNumber": "PN-007",
          "PartName": "Dummy part for testing...",
          "Revision": "A",
          "Quantity": 35,
          "batchNumber": 1
        },
        "qty": 35,
        "destinationCode": "VENDOR-200"
      }
    ],
}
```

Each `item` block under `sourceShipmentId.manifest` was missing the `_id` which is what is meant to be linked and referenced.