### PR TITLE
fix: editing shipments deletes shipment

### DIFF
--- a/src/shipment/controller.js
+++ b/src/shipment/controller.js
@@ -472,11 +472,13 @@ async function editOne(req, res) {
       );
 
       // then update newPackingSlips otherwise a conflict will occur
-      const updatedShipment = await Shipment.updateOne(
+      const updatedShipment = await Shipment.findOneAndUpdate(
         { _id: sid },
         {
           $push: {
-            manifest: { $each: newPackingSlips?.map((e) => ObjectId(e)) ?? [] },
+            manifest: {
+              $each: newPackingSlips?.map((e) => ObjectId(e)) ?? []
+            },
           },
         },
         { new: true }


### PR DESCRIPTION
**Issue**: editing a shipment was deleting them.

**Solution**: This was due to the fact that we added logic to check for empty manifests & delete the document if that was the case. The logic was incorrectly using `model.updateOne` which does not return a document. Thus when checking for `doc?.manifest?.length` this was always false, because a document was never present. Changing the model interface to `model.findOneAndUpdate` fixes it.