### PR TITLE
Create incoming delivery doc in packship when a po is cp 390

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const passport = require("passport");
 const cookieSession = require("cookie-session");
+const { CheckUserId } = require('./user/controller');
 
 require("dotenv").config();
 require("./config.passport")(passport);
@@ -12,7 +13,7 @@ const app = express();
 
 app.use(
   cors({
-    origin: [process.env.CORS_CLIENT_URL],
+    origin: [process.env.CORS_CLIENT_URL, process.env.CORS_WORKFLOW_URL],
     credentials: true,
   })
 );
@@ -28,6 +29,7 @@ app.use(
 app.use(passport.initialize());
 app.use(passport.session());
 
+
 if (process.env.NODE_ENV === "DEBUG") {
   console.debug("DEBUGGING ROUTES ARE ON !!!");
 
@@ -36,13 +38,33 @@ if (process.env.NODE_ENV === "DEBUG") {
 
 // This handles authentication
 app.use("/auth", require("./router.auth"));
-app.all("*", function (req, res, next) {
+
+app.all("*", async function (req, res, next) {
+  
+  // requests from Workflow app should have authUserId value
+  const { authUserId } = req.body;
+
   if (req.isAuthenticated()) return next();
-  else res.redirect(req.baseUrl + "/auth/google");
+  else if ( authUserId ) {
+    // check if userId is valid
+    const [ userCheckErr, isUserValid] = await CheckUserId(authUserId );
+
+    if ( userCheckErr ) return res.status(400).send(userCheckErr);   
+    if ( !isUserValid ) return res.status(404).send('Invalid User Id. Cannont process request');
+
+    ( req.locals ) 
+      ? req.locals.authUserId = authUserId
+      : req.locals = { authUserId };
+
+    return next();
+  }
+  else return res.redirect(req.baseUrl + "/auth/google");   
 });
 
 app.use("/shipments", require("./shipment/controller"));
+
 app.use("/packingSlips", require("./packingSlip/controller").router);
+
 app.use("/incomingDeliveries", require("./incomingDelivery/controller").router);
 app.use("/workOrders", require("./workOrder/controller").router);
 app.use("/users", require("./user/controller").router);

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -290,6 +290,7 @@ function CreateConsumablePO( req, res ) {
         sourcePoType: 'purchaseOrders',
         sourcePOId,
         isDueBackOn,    // this might be undefined
+        linesReceived: [],
       });
       
       await autoIncomingDelivery.save();

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -733,7 +733,6 @@ async function checkId(res, next, model, id) {
 }
 
 
-
 function addBusinessDays( days, dateStringOnly ) {
   const date = new Date();
   let i = days;
@@ -746,7 +745,8 @@ function addBusinessDays( days, dateStringOnly ) {
   }
 
   if ( dateStringOnly ) {
-    return date.toISOString().split('T')[0]
+    const [year, month, day] = date.toISOString().split('T')[0].split('-');
+    return `${month}/${day}/${year}`;
   }
 
   return date;

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -14,7 +14,7 @@ const { BlockNonAdmin } = require("../user/controller");
 
 router.get("/", getAll);
 router.put("/", createOne);
-router.put( '/autoGen', autoGenOne );
+router.put( '/autoGen', CreateConsumablePO );
 router.get("/queue", getQueue);
 router.post("/receive", setReceived);
 
@@ -250,7 +250,7 @@ function createOne(req, res) {
   );
 }
 
-function autoGenOne( req, res ) {
+function CreateConsumablePO( req, res ) {
   ExpressHandler(
     async () => {
 

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -258,7 +258,9 @@ function CreateConsumablePO( req, res ) {
       if ( !sourcePOId ) return HTTPError( 'Source doc Id not provided found.', 400 );
       if ( !poNumber ) return HTTPError( 'PO number not provided found.', 400 );
 
-      const userId = req.user._id;
+      const userId = req?.user?._id || req?.body?.authUserId;
+
+      if ( !userId ) return HTTPError( 'No userId found, cannot complete creating consumable PO.', 400 );
       const label = poNumber + '-R';
 
       const autoIncomingDelivery = new IncomingDelivery({
@@ -271,7 +273,11 @@ function CreateConsumablePO( req, res ) {
       
       await autoIncomingDelivery.save();
 
-      const data = { newIncomingDelivery: autoIncomingDelivery };
+      const data = { 
+        newIncomingDelivery: autoIncomingDelivery,
+        message: `Incoming delivery ${label} has been created.`
+      };
+      
       return { data };
     },
     res,

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -214,7 +214,9 @@ async function CreateNew(
     const newIncomingDelivery = new IncomingDelivery(deliveryInfo);
     await newIncomingDelivery.save();
 
-    return [, { incomingDelivery: newIncomingDelivery }];
+    const message = `New incoming delivery (${newIncomingDelivery.label}) created.`
+
+    return [, { incomingDelivery: newIncomingDelivery, message }];
   } catch (error) {
     LogError(error);
     return [HTTPError("Unexpected error creating incoming delivery.")];
@@ -224,7 +226,19 @@ async function CreateNew(
 /**
  * Fetch all incoming deliveries ever created.
  */
-function getAll(req, res) {}
+function getAll(req, res) {
+  ExpressHandler(
+    async () => {
+
+      return HTTPError('Route not implemented.')
+      const data = { message: 'worked getting all incoming deliveries' };
+      
+      return { data };
+    },
+    res,
+    'getting all incoming deliveries'
+  );
+}
 
 /**
  * Create a single incoming delivery.
@@ -236,9 +250,12 @@ function createOne(req, res) {
       const { internalPurchaseOrderNumber, isDueBackOn, sourceShipmentId } =
         req.body;
 
+      // for external requests
+      const { authUserId } = req.locals;
+
       const [err, data] = await CreateNew(
         internalPurchaseOrderNumber,
-        req.user._id,
+        req.user?._id || authUserId,
         isDueBackOn,
         sourceShipmentId
       );

--- a/src/incomingDelivery/controller.js
+++ b/src/incomingDelivery/controller.js
@@ -12,6 +12,8 @@ const Shipment = require("../shipment/model");
 const dayjs = require("dayjs");
 const { BlockNonAdmin } = require("../user/controller");
 
+const DEFAULT_BUSINESS_DAYS = 10;
+
 router.get("/", getAll);
 router.put("/", createOne);
 router.put( '/autoGen', CreateConsumablePO );
@@ -275,7 +277,7 @@ function CreateConsumablePO( req, res ) {
       if ( !poNumber ) return HTTPError( 'PO number not provided found.', 400 );
 
       // TODO: need to make this some way to default to 10 business days
-      const isDueBackOn = req.body.isDueBackOn || '12-31-2023';
+      const isDueBackOn = req.body.isDueBackOn || addBusinessDays(DEFAULT_BUSINESS_DAYS, true);
       
       const userId = req?.user?._id || req?.body?.authUserId;
 
@@ -727,4 +729,24 @@ async function checkId(res, next, model, id) {
       next();
     }
   }
+}
+
+
+
+function addBusinessDays( days, dateStringOnly ) {
+  const date = new Date();
+  let i = days;
+  while( i > 0 ) {
+    const day = date.getDay();
+    if ( ![0, 6].includes(day) ) {
+      i --;
+    }
+    date.setDate( date.getDate() + 1 );
+  }
+
+  if ( dateStringOnly ) {
+    return date.toISOString().split('T')[0]
+  }
+
+  return date;
 }

--- a/src/user/controller.js
+++ b/src/user/controller.js
@@ -5,7 +5,8 @@ const router = express.Router();
 
 module.exports = {
   router,
-  BlockNonAdmin
+  BlockNonAdmin,
+  CheckUserId,
 };
 
 /**
@@ -36,3 +37,19 @@ router.get('/me', async (req, res) => {
     res.status(500).send(e);
   }
 });
+
+// check if user id is valid, used for requests from Workflow app
+async function CheckUserId ( authUserId ) {
+  try {
+    if ( !authUserId ) res.status(400).send('No user Id provided.');
+
+    const user = await User.findOne({ _id: authUserId })
+      .lean()
+      .exec();
+
+    return [null, !!user];
+  } 
+  catch (e) {
+    return [e];
+  }
+}


### PR DESCRIPTION
Partially closes CP-390

Note: this was branched from `origin/hit-packship-from-workflow` branch which has not yet been merged into `main`.

Solution:
* Created `CreateConsumablePO` function at `PUT` `/autoGen` route to automatically generate an incoming delivery with `sourcePoType` of `purchaseOrders`.
* Updated logic in `getQueue` to have quick outs in the nested for loops. This was breaking with my development data.
* Other updates found on `hit-packship-from-workflow` branch.

Additional Notes: 
* `label` value is based on PO prefix + poNumber + "-R". ie PO1234-R
* `isDueBackOn` value defaults to 10 business days from the date it is submitted. This is controlled by the `DEFAULT_BUSINESS_DAYS` global.
- [ ] TODO: Do we need to do some type of check for the label structure to ensure we are not creating duplicate labels? I assume we would only want one delivery for each PO but maybe that isn't the case???